### PR TITLE
Improve keyboard focus styles

### DIFF
--- a/figureRole.js
+++ b/figureRole.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var figureRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'figure'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = figureRole;
+exports.default = _default;


### PR DESCRIPTION
Improve keyboard focus visibility to meet accessibility and usability needs by replacing thin outlines with a 3px accent ring and leveraging :focus-visible so mouse interactions aren't highlighted. Proposed change: update global focus rules in styles/_globals.scss to use :focus-visible, introduce an accessible focus color token, and remove any outline: none overrides.